### PR TITLE
Fix channels-related bugs

### DIFF
--- a/org-antlr-works-editor/src/org/antlr/works/editor/grammar/codemodel/impl/ChannelModelImpl.java
+++ b/org-antlr-works-editor/src/org/antlr/works/editor/grammar/codemodel/impl/ChannelModelImpl.java
@@ -14,6 +14,7 @@ import org.antlr.netbeans.editor.text.OffsetRegion;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.antlr.works.editor.grammar.codemodel.ChannelModel;
+import org.antlr.works.editor.grammar.codemodel.CodeElementPositionRegion;
 
 /**
  *
@@ -32,5 +33,23 @@ public class ChannelModelImpl extends AbstractCodeElementModel implements Channe
     @Override
     public Collection<? extends AbstractCodeElementModel> getMembers() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public CodeElementPositionRegion getSeek() {
+        if (this.seek == null) {
+            return super.getSeek();
+        }
+
+        return new CodeElementPositionRegionImpl(this, seek);
+    }
+
+    @Override
+    public CodeElementPositionRegion getSpan() {
+        if (this.span == null) {
+            return super.getSpan();
+        }
+
+        return new CodeElementPositionRegionImpl(this, span);
     }
 }

--- a/org-antlr-works-editor/src/org/antlr/works/editor/grammar/formatting/GrammarIndentTask.java
+++ b/org-antlr-works-editor/src/org/antlr/works/editor/grammar/formatting/GrammarIndentTask.java
@@ -731,11 +731,10 @@ public class GrammarIndentTask extends AbstractIndentTask {
                 return Tuple.create(ctx, 0);
             }
 
-            // align to the previous element
-            for (int i = priorSiblings.size() - 2; i >= 0; i--) {
+            // align to the previous element; stop at the first id rule, index 0 is the TOKENS terminal itself
+            for (int i = priorSiblings.size() - 2; i >= 1; i--) {
                 ParseTree sibling = priorSiblings.get(i);
-                // stop at the first id rule, index 0 is the TOKENS terminal itself
-                if (i == 1 || ParseTrees.elementStartsLine(sibling)) {
+                if (ParseTrees.elementStartsLine(sibling)) {
                     return Tuple.create(sibling, 0);
                 }
             }
@@ -754,11 +753,10 @@ public class GrammarIndentTask extends AbstractIndentTask {
                 return Tuple.create(ctx, 0);
             }
 
-            // align to the previous element
-            for (int i = priorSiblings.size() - 2; i >= 0; i--) {
+            // align to the previous element; stop at the first id rule, index 0 is the CHANNELS terminal itself
+            for (int i = priorSiblings.size() - 2; i >= 1; i--) {
                 ParseTree sibling = priorSiblings.get(i);
-                // stop at the first id rule, index 0 is the CHANNELS terminal itself
-                if (i == 1 || ParseTrees.elementStartsLine(sibling)) {
+                if (ParseTrees.elementStartsLine(sibling)) {
                     return Tuple.create(sibling, 0);
                 }
             }


### PR DESCRIPTION
* Fix Go To Definition for channels (e.g. `custom` in `-> channel(custom)`)
* Fix smart indent of the first element within a `tokens{}` or `channels{}` spec